### PR TITLE
Allow developers to specify the path of a YARA rules file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ __pycache__
 /**/.unpacker_history
 /**/unpacked.exe
 /**/.unipacker_brokenimport.exe
+*.egg-info

--- a/unipacker/core.py
+++ b/unipacker/core.py
@@ -16,14 +16,15 @@ from unipacker.apicalls import WinApiCalls
 from unipacker.headers import PE, get_disk_headers, conv_to_class_header, parse_disk_to_header
 from unipacker.kernel_structs import TEB, PEB, PEB_LDR_DATA, LIST_ENTRY
 from unipacker.pe_structs import SectionHeader, IMAGE_SECTION_HEADER, ImportDescriptor, Import
-from unipacker.unpackers import get_unpacker
+from unipacker.unpackers import get_unpacker, DEFAULT_YARA_PATH
 from unipacker.utils import merge, align, convert_to_string, InvalidPEFile, print_single_disass
 
 
 class Sample(object):
 
-    def __init__(self, path, auto_default_unpacker=True):
+    def __init__(self, path, yara_path=DEFAULT_YARA_PATH, auto_default_unpacker=True):
         self.path = path
+        self.yara_path = yara_path
         self.init_headers()
         self.imports = set()
         self.dllname_to_functionlist = collections.OrderedDict()  # dll_name -> [(name/ordinal, addr), ...]

--- a/unipacker/packer_signatures.yar
+++ b/unipacker/packer_signatures.yar
@@ -95,9 +95,10 @@ rule mew{
         description = "MEW packed file"
         date = "2019-01-25"
     strings:
-        $mew = "MEW"
+        $mew1 = "MEW"
+        $mew2 = {50 72 6F 63 41 64 64 72 65 73 73 00 E9 [6-7] 00 00 00 00 00 00 00 00 00 [7] 00}
     condition:
-        pe32 and $mew
+        pe32 and ( $mew1 and $mew2 )
 }
 
 

--- a/unipacker/unpackers.py
+++ b/unipacker/unpackers.py
@@ -7,9 +7,10 @@ import unipacker
 from unipacker.imagedump import ImageDump, ImportRebuilderDump, PEtiteDump, MEWDump, YZPackDump
 from unipacker.utils import InvalidPEFile
 
+DEFAULT_YARA_PATH = f"{os.path.dirname(unipacker.__file__)}/packer_signatures.yar"
+
 
 class DefaultUnpacker(object):
-
     def __init__(self, sample):
         self.name = "unknown"
         self.sample = sample
@@ -228,31 +229,19 @@ def identifypacker(sample, yar):
     return result, matches
 
 
-def generate_label(l):
-    if 'upx' in str(l):
-        return 'upx'
-    elif "petite" in str(l):
-        return "petite"
-    elif 'mew' in str(l):
-        return 'mew'
-    elif 'mpress' in str(l):
-        return 'mpress'
-    elif "aspack" in str(l):
-        return "aspack"
-    elif "fsg" in str(l):
-        return "fsg"
-    elif "pecompact" in str(l):
-        return "pecompact"
-    elif "upack" in str(l):
-        return "upack"
-    elif "yzpack" in str(l):
-        return "yzpack"
-    else:
-        return 'unknown'
+def generate_label(match):
+    labels = [
+        'upx', 'petite', 'mew', 'mpress', 'aspack',
+        'fsg', 'pecompact', 'upack', 'yzpack'
+    ]
+    for packer in labels:
+        if packer in str(match):
+            return packer
+    return 'unknown'
 
 
 def get_unpacker(sample, auto_default_unpacker=True):
-    yar = f"{os.path.dirname(unipacker.__file__)}/packer_signatures.yar"
+    yar = sample.yara_path
     packer, yara_matches = identifypacker(sample.path, yar)
     packers = {
         "upx": UPXUnpacker,


### PR DESCRIPTION
Simple change to allow developers to specify the path of a YARA rules file (or even includes). 

```python3
from unipacker.core import Sample
sample = Sample(pe, yara_path='/path/to/another/packer_signatures.yar')
```

Bonus: improvement to MEW packer rules as it will avoid PEs to be identified as packed if they have the `MEW` string inside the binary.